### PR TITLE
prince 0.10.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,6 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - setuptools
-    - wheel
   run:
     - python
     - scikit-learn >=1.0.2,<2.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,6 @@ requirements:
     - python
     - poetry-core 1.5.1
     - pip
-    - setuptools
-    - wheel
   run:
     - python
     - scikit-learn >=1.0.2,<2.0.0


### PR DESCRIPTION
Add a new feedstock: prince 0.10.8

License: https://github.com/MaxHalford/prince/blob/master/LICENSE
Requirements: https://github.com/MaxHalford/prince/blob/master/pyproject.toml

Actions:
1. Remove incorrect duplication in `host`

Notes:
- I requested bumping the `altair` upper bound https://github.com/MaxHalford/prince/pull/159 and the version **0.10.8** has it https://github.com/MaxHalford/prince/commit/5d9101f4a40339cdc23c0c1f6ccc033f3a267c2f and it just has been released https://pypi.org/project/prince/0.10.8/#history